### PR TITLE
Fix usage of nil value

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -23,7 +23,9 @@ RegisterNetEvent('esx_dmvschool:pay')
 AddEventHandler('esx_dmvschool:pay', function(price)
 	local _source = source
 	local xPlayer = ESX.GetPlayerFromId(_source)
-
-	xPlayer.removeMoney(price)
-	TriggerClientEvent('esx:showNotification', _source, _U('you_paid', ESX.Math.GroupDigits(price)))
+		
+	if xPlayer ~= nil then
+		xPlayer.removeMoney(price)
+		TriggerClientEvent('esx:showNotification', _source, _U('you_paid', ESX.Math.GroupDigits(price)))
+	end
 end)


### PR DESCRIPTION
I'm having this issue:
```
Error running system event handling function for resource esx_dmvschool: citizen:/scripting/lua/scheduler.lua:41: Failed to execute thread: @esx_dmvschool/server/main.lua:27: attempt to index a nil value (local 'xPlayer')
stack traceback:
        @esx_dmvschool/server/main.lua:27: in upvalue 'handler'
        citizen:/scripting/lua/scheduler.lua:219: in function <citizen:/scripting/lua/scheduler.lua:218>
stack traceback:
        [C]: in function 'error'
        citizen:/scripting/lua/scheduler.lua:41: in field 'CreateThreadNow'
        citizen:/scripting/lua/scheduler.lua:218: in function <citizen:/scripting/lua/scheduler.lua:182>
```

This will fix it