### PR TITLE
refactor(sql): change license labels to english

### DIFF
--- a/esx_dmvschool.sql
+++ b/esx_dmvschool.sql
@@ -1,6 +1,6 @@
 INSERT INTO `licenses` (`type`, `label`) VALUES
-	('dmv', 'Code de la route'),
-	('drive', 'Permis de conduire'),
-	('drive_bike', 'Permis moto'),
-	('drive_truck', 'Permis camion')
+	('dmv', 'Driving Permit'),
+	('drive', 'Driver License'),
+	('drive_bike', 'Motorcycle License'),
+	('drive_truck', 'Truck License')
 ;


### PR DESCRIPTION
The labels in `esx_dmvschool.sql` are in French by default. Because the whole resource is in English by default, this PR translates those labels from French to English.